### PR TITLE
Implemented support for multinomial regression

### DIFF
--- a/bin/run_megaattitude_rnn_regression.py
+++ b/bin/run_megaattitude_rnn_regression.py
@@ -1,12 +1,33 @@
+import argparse
 import numpy as np
 import pandas as pd
+
+from torch.nn import LSTM, SmoothL1Loss, L1Loss, CrossEntropyLoss
 
 from factslab.utility import load_glove_embedding
 from factslab.datastructures import ConstituencyTree
 from factslab.pytorch.childsumtreelstm import ChildSumConstituencyTreeLSTM
 from factslab.pytorch.rnnregression import RNNRegressionTrainer
 
-data = pd.read_csv('../../factslab-data/megaattitude/megaattitude_v1.csv')
+## initialize argument parser
+description = 'Run an RNN regression on MegaAttitude.'
+parser = argparse.ArgumentParser(description=description)
+
+## file handling
+parser.add_argument('--data', 
+                    type=str, 
+                    default='../../factslab-data/megaattitude/megaattitude_v1.csv')
+parser.add_argument('--structures', 
+                    type=str, 
+                    default='../../factslab-data/megaattitude/structures.tsv')
+parser.add_argument('--regressiontype', 
+                    type=str, 
+                    default="linear")
+
+## parse arguments
+args = parser.parse_args()
+
+data = pd.read_csv(args.data)
 
 # remove subjects that are marked for exclusion
 data = data[~data.exclude]
@@ -17,20 +38,28 @@ data = data[~data.response.isnull()]
 # the intransitive frame is denoted by an empty string, so make it overt
 data.loc[data.frame.isnull(),'frame'] = 'null'
 
-# convert responses to logit ridit scores
-data['response'] = data.groupby('participant').response.apply(lambda x: x.rank()/(len(x)+1.))
-data['response'] = np.log(data.response) - np.log(1.-data.response)
-
+if args.regressiontype == "multinomial":
+    # make smallest response value 0
+    data['response'] = data.response.astype(int) - 1
+    
+else:
+    # convert responses to logit ridit scores
+    data['response'] = data.groupby('participant').response.apply(lambda x: x.rank()/(len(x)+1.))
+    data['response'] = np.log(data.response) - np.log(1.-data.response)
+    
 # convert "email" to "e-mail" to deal with differences between
 # megaattitude_v1.csv and structures.tsv
 data['condition'] = data.verb.replace('email', 'e-mail')+'-'+data.frame+'-'+data.voice
 
 # load structures into a dictionary
-with open('../../factslab-data/megaattitude/structures.tsv') as f:
+with open(args.structures) as f:
     structures = dict([line.replace(',', 'COMMA').strip().split('\t') for line in f])
 
     structures = {k: ConstituencyTree.fromstring(s) for k, s in structures.items()}
 
+for s in structures.values():
+    s.collapse_unary(True, True)
+    
 # get the structure IDs from the dictionary keys
 conditions = list(structures.keys())
 
@@ -46,12 +75,14 @@ vocab = list({word
 embeddings = load_glove_embedding('../../../embeddings/glove/glove.42B.300d', vocab)
 
 # train the model
-trainer = RNNRegressionTrainer(embeddings=embeddings,
+trainer = RNNRegressionTrainer(embeddings=embeddings, gpu=True,
                                rnn_classes=ChildSumConstituencyTreeLSTM,
-                               rnn_hidden_sizes=300)
-trainer.fit(structures=[[structures[c] for c in data.condition.values]],
-            targets=data.response.values,
-            lr=1., batch_size=1000)
+                               regression_type=args.regressiontype,
+                               rnn_hidden_sizes=300, num_rnn_layers=1,
+                               regression_hidden_sizes=(150,75))
+trainer.fit(X=[[structures[c] for c in data.condition.values]],
+            Y=data.response.values,
+            lr=1., batch_size=100)
 
 # trainer = RNNRegressionTrainer(embeddings=embeddings, gpu=True,
 #                                rnn_classes=[LSTM, ChildSumConstituencyTreeLSTM],
@@ -59,4 +90,4 @@ trainer.fit(structures=[[structures[c] for c in data.condition.values]],
 # trainer.fit(structures=[[structures[c].words() for c in data.condition.values],
 #                         [structures[c] for c in data.condition.values]],
 #             targets=data.response.values,
-#             lr=1.)
+#             lr=1., batch_size=100)


### PR DESCRIPTION
There is now support for multinomial regression with a cross-entropy loss in the `factslab.pytorch.rnnregression` module. To use multinomial regression, pass `regression_type="multinomial"` to `RNNRegressionTrainer` in `factslab.pytorch.rnnregression`. 

Relevant changes were percolated to `run_megaattitude_rnn_regression.py` (previously `run_rnn_regression.py`) in `bin/`. In addition, an argument parser for that script was implemented, allowing one to pass input file paths and a `--regressiontype` parameter.