### PR TITLE
updated softmax dim parameter 

### DIFF
--- a/factslab/pytorch/rnnregression.py
+++ b/factslab/pytorch/rnnregression.py
@@ -249,7 +249,7 @@ class RNNRegression(torch.nn.Module):
 
     def _run_attention(self, h_all, return_weights=False):
         att_raw = torch.mm(h_all, self.attention_map[:,None])
-        att = F.softmax(att_raw.squeeze())
+        att = F.softmax(att_raw.squeeze(), dim=0)  
 
         if return_weights:
             return att


### PR DESCRIPTION
Included dimension as a parameter in softmax function to avoid the following warning in the latest PyTorch:
UserWarning: Implicit dimension choice for softmax has been deprecated. Change the call to include dim=X as an argument.